### PR TITLE
Add a CI job to compile on multiple platforms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+
+name: Build
+
+on:
+  push:
+    workflow_dispatch:
+    branches:
+      - main
+    tags:
+      - '*'
+  pull_request:
+  workflow_dispatch:
+
+
+jobs:
+  compile:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-24.04,
+             windows-latest, 
+             macos-14,
+            ] 
+    steps:
+      - uses: actions/checkout@v4
+          
+      - uses: Swatinem/rust-cache@v2
+      
+      - name: Compile psp
+        run: cargo build --release
+
+      - name: Upload built artefacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: built-${{ matrix.os }}
+          path: target


### PR DESCRIPTION
Enable incremental build cacheing between workflow runs with Swatinem/rust-cache

Create build.yml

Update build.yml

Don't install Python in CI build job (on Windows the action compiles Python)