### PR TITLE
fix: avoid index panic in Makefile generation when no optional targets

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2309,7 +2309,7 @@ help:
     // Add all targets
     make_options.remove(0);
     make_options.remove(0);
-    if make_options[2] == "test" {
+    if make_options.get(2) == Some(&"test") {
         let removed_test = make_options.remove(2);
         make_options.insert(0, removed_test);
     }
@@ -2458,4 +2458,20 @@ fn main() {
         "info: python project `{name}` created at `{}`",
         absolute(root).unwrap().display()
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::create_dir_all;
+
+    #[test]
+    fn makefile_without_optional_targets() {
+        let dir = std::env::temp_dir().join("psp_makefile_test_minimal");
+        create_dir_all(&dir).unwrap();
+        prj_makefile(dir.to_str().unwrap(), "demo", false, false, false);
+        let makefile = read_to_string(dir.join("Makefile")).unwrap();
+        assert!(makefile.contains("all: run clean"));
+        remove_dir_all(&dir).ok();
+    }
 }


### PR DESCRIPTION
Fixes #5. When a project is created without tests, build, or container targets, `prj_makefile` strips the first two options and then indexes `make_options[2]`, which panics with "index out of bounds: the len is 2 but the index is 2" since only "run" and "clean" remain. Switched the check to `make_options.get(2)` so the optional test target is moved to the front only when it is actually present, and added a regression test for the no-optional-targets case.